### PR TITLE
Update CLI setup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "thresh"
 version = "0.0.1"
-description = "Tiny webhook based continuous delivery server for your VPS"
+description = "Tiny continuous deployment server for VPS"
 authors = ["gillchristian <gillchristiang@gmail.com>", "ndelvalle <nicolas.delvalle@gmail.com>"]
 edition = "2018"
 

--- a/README.md
+++ b/README.md
@@ -1,44 +1,46 @@
 # Thresh
 
-🛳 Tiny GitHub webhooks based CI/CD server for your VPS
+🛳 Tiny continuous deployment server for VPS
 
 ![Rust](https://github.com/huemul/thresh/workflows/Rust/badge.svg)
 
-## Install & setup
+## Install and setup
 
-Download the latest binary from the release and give exec permission:
+Download the latest [released binary](https://github.com/Huemul/thresh/releases) and mark the file as executable with the chmod command:
 
 ```
-$ wget -O thresh "https://github.com/Huemul/thresh/releases/download/v0.0.1/thresh_x86-64-linux"
+$ wget -O thresh "https://github.com/Huemul/thresh/releases/download/v0.0.1/thresh-x86-64-linux"
 $ chmod +x thresh
 ```
 
-**NOTE**: you probably want to change the version (`v0.0.1`) to the [latest available release](https://github.com/Huemul/thresh/releases).
-
-Now that Thresh is available:
+Now that Thresh is available, the `help` subcommand can be run to display the CLI interface:
 
 ```
 $ ./thresh --help
 thresh 0.0.1
-gillchristian <gillchristiang@gmail.com>:ndelvalle <nicolas.delvalle@gmail.com>
-Tiny GitHub webhooks based CI/CD server for your VPS
+gillchristian <gillchristiang@gmail.com>, ndelvalle <nicolas.delvalle@gmail.com>
+Tiny continuous deployment server for VPS
 
 USAGE:
-    thresh [OPTIONS]
+    thresh <SUBCOMMAND>
 
 FLAGS:
     -h, --help       Prints help information
     -V, --version    Prints version information
 
-OPTIONS:
-    -c, --config <config>        Path to the Threshfile [default: ./.threshfile]
-    -l, --logs-dir <logs-dir>    Sets a custom logs directory
-    -p, --port <port>            Sets a custom server port
+SUBCOMMANDS:
+    help     Prints this message or the help of the given subcommand(s)
+    start    Start thresh agent
+    token    Create a token based on the specified secret to authorize agent connections
 ```
 
-Next create a `.threshfile` with the configuration to run for any project you want. For a example threshfile see [sample.threshfile](https://github.com/Huemul/thresh/blob/master/sample.threshfile).
+Next create a `.threshfile` with the required configuration to deploy projects. Optionally this file can contain global Thresh configuration.
+A `threshfile` example can be found [here](https://github.com/Huemul/thresh/blob/master/sample.threshfile).
 
-Create a systemd service file (`/etc/systemd/system/thresh.service`) with the following contents.
+
+## Systemd configuration (Optional)
+
+Create a systemd service file (`/etc/systemd/system/thresh.service`) with the following attributes:
 
 ```
 [Unit]
@@ -48,30 +50,19 @@ Description=Thresh
 ExecStart=/path/to/thresh -c /path/to/.threshfile -l /path/to/thresh-logs -p 8080
 ```
 
-**NOTE**: Make sure to update it with the right options and path to the Thresh binary.
-
-Now enable and start thresh service:
+Then enable and start Thresh service:
 
 ```bash
-# might require sudo
+# These commands might require sudo
 $ systemctl enable /etc/systemd/system/thresh.service
 $ systemctl start thresh
 ```
 
-To see logs and status the following commands are useful:
+To read logs and check status the following commands can be used:
 
 ```bash
 $ systemctl status thresh
 $ journalctl -u thresh -b
-```
-
-Once Thresh is running and exposed to the internet on your VPS is time to [add the GitHub webhook to a repo](https://developer.github.com/webhooks/creating/). Create a webhook that sends `push` events to the webhook URL (`<domain-running-thresh>/webhook`).
-
-Thresh responds with a "job id" in case a webhook triggered a job. Which can be used to see the log file online:
-
-```
-GET <domain-running-thresh>/logs
-GET <domain-running-thresh>/logs/:{job_id}
 ```
 
 ## Development
@@ -100,11 +91,10 @@ cargo watch -x test
 ### Testing the webhook locally
 
 ```bash
-curl -d {
-  "ref": "refs/heads/master",
-  "repository": { "full_name": "username/repository" },
-  "sender": { "login": "username" }
-}' -H "Content-Type: application/json" -X POST http://localhost:8080/webhook
+curl -X POST 'http://localhost:8080/webhook' \
+--header 'Authorization: Bearer ********' \
+--header 'Content-Type: application/json' \
+--data-raw '{
+    "name": "foo-project"
+}'
 ```
-
-:point_up: That can also be used to trigger the webhook from other sources (eg. any CI/CD server). In that case, make sure the URL is passed by a secret.

--- a/sample.threshfile
+++ b/sample.threshfile
@@ -2,22 +2,18 @@
 port = 8080
 logs_dir = "./logs"
 
-# a list of projects to run jobs for
+# List of projects to run jobs for
 
 [[projects]]
-# the repository where the webhook is set up
-repository = "username/repository"
+# Unique project identifier
+name = "foo-project"
 
-# run only for this branch
-branch = "master"
-
-# path where the commands should run the tilde (~) is properly expanded
-#
+# Path where the commands should run. The tilde (~) is properly expanded
 # NOTE: the path does not have to be a git repo
 #       it can be any directory
 path = "~/path/to/project/directory"
 
-# list of commands to run
+# List of commands to run
 commands = [
   "git pull --rebase",
   "docker-compose down",
@@ -25,20 +21,17 @@ commands = [
 ]
 
 [[projects]]
-repository = "username/other"
-branch = "development"
-path = "~/path/to/other"
+name = "sarasa"
+path = "~/path/to/sarasa"
 commands = [
   "git pull",
-  "./reset.sh",
+  "./restart-serever.sh",
 ]
 
 [[projects]]
-repository = "username/yet-another"
-branch = "master"
-path = "~/path/to/another"
+name = "baz"
+path = "~/path/to/baz"
 commands = [
   "git pull",
-  "systemctl stop yet_another",
-  "systemctl start yet_another",
+  "systemctl restart yet_another"
 ]


### PR DESCRIPTION
Update CLI to have 2 commands `start` and `token`:

```
thresh 0.0.1
gillchristian <gillchristiang@gmail.com>, ndelvalle <nicolas.delvalle@gmail.com>
Tiny continuous deployment server for VPS

USAGE:
    thresh <SUBCOMMAND>

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information

SUBCOMMANDS:
    help     Prints this message or the help of the given subcommand(s)
    start    Start thresh agent
    token    Create a token based on the specified secret to authorize agent connections
```

Each command has its options:

Start:
```
thresh-start 0.0.1
Start thresh agent

USAGE:
    thresh start [OPTIONS]

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information

OPTIONS:
    -c, --config <config>        Path to Threshfile [default: .threshfile]
    -l, --logs-dir <logs-dir>    Custom logs directory
    -p, --port <port>            Custom server port
    -s, --secret <secret>        Secret to authenticate tokens
```

Token:
```
thresh-token 0.0.1
Create a token based on the specified secret to authorize agent connections

USAGE:
    thresh token [OPTIONS]

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information

OPTIONS:
    -c, --config <config>    Path to Threshfile [default: .threshfile]
    -s, --secret <secret>    Secret to authenticate tokens
```

This PR also updates the README.md a bit.