### PR TITLE
feat: Add info and healthz endpoints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "thresh"
 version = "0.0.1"
-description = "Tiny continuous deployment server for VPS"
+description = "Tiny deployment agent"
 authors = ["gillchristian <gillchristiang@gmail.com>", "ndelvalle <nicolas.delvalle@gmail.com>"]
 edition = "2018"
 
@@ -13,6 +13,7 @@ actix-files = "0.2.2"
 actix-rt = "1.1.1"
 actix-web = "2.0.0"
 actix-web-httpauth = "0.4.1"
+async-std = "1.6.1"
 chrono = "0.4"
 clap = "2.33.1"
 env_logger = "0.7"
@@ -22,4 +23,3 @@ serde = "1.0"
 serde_json = "1.0"
 shellexpand = "2.0"
 toml = "0.5"
-async-std = "1.6.1"

--- a/README.md
+++ b/README.md
@@ -1,59 +1,66 @@
 # Thresh
 
-🛳 Tiny continuous deployment server for VPS
+🛳 Tiny deployment agent
 
 ![Rust](https://github.com/huemul/thresh/workflows/Rust/badge.svg)
 
 ## Install and setup
 
-Download the latest [released binary](https://github.com/Huemul/thresh/releases) and mark the file as executable with the chmod command:
+Download the latest [released binary](https://github.com/Huemul/thresh/releases)
+and add executable permissions:
 
 ```
 $ wget -O thresh "https://github.com/Huemul/thresh/releases/download/v0.0.1/thresh-x86-64-linux"
 $ chmod +x thresh
 ```
 
-Now that Thresh is available, the `help` subcommand can be run to display the CLI interface:
+Now that Thresh is available, the `help` subcommand can be run to display the
+CLI information:
 
 ```
 $ ./thresh --help
 thresh 0.0.1
-gillchristian <gillchristiang@gmail.com>, ndelvalle <nicolas.delvalle@gmail.com>
-Tiny continuous deployment server for VPS
+Tiny deployment agent
 
 USAGE:
-    thresh <SUBCOMMAND>
+    thresh [OPTIONS] <SUBCOMMAND>
 
 FLAGS:
     -h, --help       Prints help information
     -V, --version    Prints version information
 
+OPTIONS:
+    -c, --config <config>    Path to Threshfile [default: .threshfile]
+    -s, --secret <secret>    Secret to generate and authenticate the token. Can also be provided in the Threshfile
+
 SUBCOMMANDS:
     help     Prints this message or the help of the given subcommand(s)
-    start    Start thresh agent
-    token    Create a token based on the specified secret to authorize agent connections
+    serve    Start thresh agent server
+    token    Create a token based on the secret to authorize agent connections
 ```
 
-Next create a `.threshfile` with the required configuration to deploy projects. Optionally this file can contain global Thresh configuration.
-A `threshfile` example can be found [here](https://github.com/Huemul/thresh/blob/master/sample.threshfile).
+Next create a `.threshfile` with the required configuration to deploy projects.
+Optionally this file can contain global Thresh configuration. A `threshfile`
+example can be found
+[here](https://github.com/Huemul/thresh/blob/master/sample.threshfile).
 
+### Systemd configuration (Optional)
 
-## Systemd configuration (Optional)
-
-Create a systemd service file (`/etc/systemd/system/thresh.service`) with the following attributes:
+Create a systemd service file (`/etc/systemd/system/thresh.service`) with the
+following attributes:
 
 ```
 [Unit]
 Description=Thresh
 
 [Service]
-ExecStart=/path/to/thresh -c /path/to/.threshfile -l /path/to/thresh-logs -p 8080
+ExecStart=/path/to/thresh -c /path/to/.threshfile -s super-secret-secret serve -l /path/to/thresh-logs -p 8080
 ```
 
 Then enable and start Thresh service:
 
 ```bash
-# These commands might require sudo
+# Might require sudo
 $ systemctl enable /etc/systemd/system/thresh.service
 $ systemctl start thresh
 ```
@@ -63,6 +70,17 @@ To read logs and check status the following commands can be used:
 ```bash
 $ systemctl status thresh
 $ journalctl -u thresh -b
+```
+
+### Trigger jobs
+
+Once Thresh is running and exposed to the internet, deployment jobs can be
+triggered by POSTing to the `/webhook` endpoint wiht the project name.
+
+```bash
+curl -X POST 'https://thresh.yourdomain.com/webhook' \
+  -H 'Authorization: Bearer ********' \
+  -d '{ "name": "foo-project" }'
 ```
 
 ## Development
@@ -86,15 +104,4 @@ cargo test
 
 # Watch mode
 cargo watch -x test
-```
-
-### Testing the webhook locally
-
-```bash
-curl -X POST 'http://localhost:8080/webhook' \
---header 'Authorization: Bearer ********' \
---header 'Content-Type: application/json' \
---data-raw '{
-    "name": "foo-project"
-}'
 ```

--- a/src/main.rs
+++ b/src/main.rs
@@ -236,7 +236,7 @@ fn cli<'a, 'b>() -> clap::App<'a, 'b> {
                 .takes_value(true),
         )
         .subcommand(
-            clap::App::new("start")
+            clap::App::new("serve")
                 .about("Start thresh agent")
                 .arg(
                     clap::Arg::with_name("port")


### PR DESCRIPTION
Add support endpoints

- `/info` responds with version (we should probably add some more stuff here, maybe the commit?)
- `/healthz` for health checking (responds with 200)

Small refactor on the CLI

- Extract CLI declaration to a function
- Remove authors from the help
- Move secret y config to the base cmd (since they are required / used on both subcommands)
- Rename `start` to `serve`