### PR TITLE
Refactor Action to have only one job

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches:
       - master
+    tags:
+      - 'v*.*.*'
+      - 'alpha_v*'
   pull_request:
     branches:
       - master
@@ -47,16 +50,10 @@ jobs:
           command: fmt
           args: --all -- --check
 
-      - name: Run cargo build
+      - name: Run cargo check
         uses: actions-rs/cargo@v1
         with:
-          command: build
-
-      - name: Run cargo build (release)
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --release
+          command: check
 
       - name: Run cargo clippy
         uses: actions-rs/cargo@v1


### PR DESCRIPTION
Only one job in the action

- all steps there, if one fails the rest won't run
- caching is done once for all the jobs
- release is still optional for tags only