### PR TITLE
fix: Do not write NUL to metadata file

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::fs::OpenOptions;
-use std::io::{Seek,SeekFrom, Write};
+use std::io::{Seek, SeekFrom, Write};
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::process::{Command, Output};
 use std::{fs, process, str, thread};


### PR DESCRIPTION
Also parse metadata as Metadata instead of `serde::Value` which means if whatever is written to the file does not match the Metadata the parsing will fail.

Fix of the file: good ol' copy from StackOverflow https://stackoverflow.com/a/50691004/4530566

Note: I don't really know why this was happening but :man_shrugging: 

For references, this is how vim would show the file:

![image](https://user-images.githubusercontent.com/8309423/85794678-4eb83200-b737-11ea-9810-afd40308c287.png)

And what that `^@` symbol means https://stackoverflow.com/a/2591309/4530566

